### PR TITLE
Chimera options

### DIFF
--- a/q2_dada2/_denoise.py
+++ b/q2_dada2/_denoise.py
@@ -33,6 +33,7 @@ def _check_featureless_table(fp):
 
 _WHOLE_NUM = (lambda x: x >= 0, 'non-negative')
 _NAT_NUM = (lambda x: x > 0, 'greater than zero')
+_CHIM_STR = (lambda x: x in {'pooled', 'consensus', 'none'}, 'pooled, consensus or none')
 # Better to choose to skip, than to implicitly ignore things that KeyError
 _SKIP = (lambda x: True, '')
 _valid_inputs = {
@@ -44,7 +45,7 @@ _valid_inputs = {
     'trim_left_r': _WHOLE_NUM,
     'max_ee': _NAT_NUM,
     'trunc_q': _WHOLE_NUM,
-    'chimera_method': (lambda x: x in {'pooled', 'consensus', 'none'}),
+    'chimera_method': _CHIM_STR,
     'min_parent_abundance': _NAT_NUM,
     'n_threads': _WHOLE_NUM,
     # 0 is technically allowed, but we don't want to support it because it only

--- a/q2_dada2/_denoise.py
+++ b/q2_dada2/_denoise.py
@@ -44,6 +44,8 @@ _valid_inputs = {
     'trim_left_r': _WHOLE_NUM,
     'max_ee': _NAT_NUM,
     'trunc_q': _WHOLE_NUM,
+    'chimera_method': _SKIP, # TEST FOR VALIDITY HERE? Value should be 'pooled', 'consensus' or 'none'
+    'min_parent_abundance': _NAT_NUM,
     'n_threads': _WHOLE_NUM,
     # 0 is technically allowed, but we don't want to support it because it only
     # takes all reads from the first sample (alphabetically by sample id)
@@ -89,7 +91,8 @@ def _denoise_helper(biom_fp, hashed_feature_ids):
 
 def denoise_single(demultiplexed_seqs: SingleLanePerSampleSingleEndFastqDirFmt,
                    trunc_len: int, trim_left: int=0, max_ee: float=2.0,
-                   trunc_q: int=2, n_threads: int=1,
+                   trunc_q: int=2, chimera_method: str='pooled',
+                   min_parent_abundance: float=1.0, n_threads: int=1,
                    n_reads_learn: int=1000000, hashed_feature_ids: bool=True
                    ) -> (biom.Table, DNAIterator):
     _check_inputs(**locals())
@@ -101,6 +104,7 @@ def denoise_single(demultiplexed_seqs: SingleLanePerSampleSingleEndFastqDirFmt,
         cmd = ['run_dada_single.R',
                str(demultiplexed_seqs), biom_fp, temp_dir_name,
                str(trunc_len), str(trim_left), str(max_ee), str(trunc_q),
+               str(chimera_method), str(min_parent_abundance),
                str(n_threads), str(n_reads_learn)]
         try:
             run_commands([cmd])
@@ -119,7 +123,8 @@ def denoise_single(demultiplexed_seqs: SingleLanePerSampleSingleEndFastqDirFmt,
 def denoise_paired(demultiplexed_seqs: SingleLanePerSamplePairedEndFastqDirFmt,
                    trunc_len_f: int, trunc_len_r: int,
                    trim_left_f: int=0, trim_left_r: int=0,
-                   max_ee: float=2.0, trunc_q: int=2, n_threads: int=1,
+                   max_ee: float=2.0, trunc_q: int=2, chimera_method: str='pooled',
+                   min_parent_abundance: float=1.0, n_threads: int=1,
                    n_reads_learn: int=1000000, hashed_feature_ids: bool=True
                    ) -> (biom.Table, DNAIterator):
     _check_inputs(**locals())
@@ -149,6 +154,7 @@ def denoise_paired(demultiplexed_seqs: SingleLanePerSamplePairedEndFastqDirFmt,
                str(trunc_len_f), str(trunc_len_r),
                str(trim_left_f), str(trim_left_r),
                str(max_ee), str(trunc_q),
+               str(chimera_method), str(min_parent_abundance),
                str(n_threads), str(n_reads_learn)]
         try:
             run_commands([cmd])

--- a/q2_dada2/_denoise.py
+++ b/q2_dada2/_denoise.py
@@ -33,7 +33,8 @@ def _check_featureless_table(fp):
 
 _WHOLE_NUM = (lambda x: x >= 0, 'non-negative')
 _NAT_NUM = (lambda x: x > 0, 'greater than zero')
-_CHIM_STR = (lambda x: x in {'pooled', 'consensus', 'none'}, 'pooled, consensus or none')
+_CHIM_STR = (lambda x: x in {'pooled', 'consensus', 'none'},
+             'pooled, consensus or none')
 # Better to choose to skip, than to implicitly ignore things that KeyError
 _SKIP = (lambda x: True, '')
 _valid_inputs = {

--- a/q2_dada2/_denoise.py
+++ b/q2_dada2/_denoise.py
@@ -44,9 +44,7 @@ _valid_inputs = {
     'trim_left_r': _WHOLE_NUM,
     'max_ee': _NAT_NUM,
     'trunc_q': _WHOLE_NUM,
-    'chimera_method': _SKIP,
-    # TEST chimera_method FOR VALIDITY HERE?
-    # Value should be 'pooled', 'consensus' or 'none'
+    'chimera_method': (lambda x: x in {'pooled', 'consensus', 'none'}),
     'min_parent_abundance': _NAT_NUM,
     'n_threads': _WHOLE_NUM,
     # 0 is technically allowed, but we don't want to support it because it only

--- a/q2_dada2/_denoise.py
+++ b/q2_dada2/_denoise.py
@@ -44,7 +44,9 @@ _valid_inputs = {
     'trim_left_r': _WHOLE_NUM,
     'max_ee': _NAT_NUM,
     'trunc_q': _WHOLE_NUM,
-    'chimera_method': _SKIP, # TEST FOR VALIDITY HERE? Value should be 'pooled', 'consensus' or 'none'
+    'chimera_method': _SKIP,
+    # TEST chimera_method FOR VALIDITY HERE?
+    # Value should be 'pooled', 'consensus' or 'none'
     'min_parent_abundance': _NAT_NUM,
     'n_threads': _WHOLE_NUM,
     # 0 is technically allowed, but we don't want to support it because it only
@@ -123,7 +125,8 @@ def denoise_single(demultiplexed_seqs: SingleLanePerSampleSingleEndFastqDirFmt,
 def denoise_paired(demultiplexed_seqs: SingleLanePerSamplePairedEndFastqDirFmt,
                    trunc_len_f: int, trunc_len_r: int,
                    trim_left_f: int=0, trim_left_r: int=0,
-                   max_ee: float=2.0, trunc_q: int=2, chimera_method: str='pooled',
+                   max_ee: float=2.0, trunc_q: int=2,
+                   chimera_method: str='pooled',
                    min_parent_abundance: float=1.0, n_threads: int=1,
                    n_reads_learn: int=1000000, hashed_feature_ids: bool=True
                    ) -> (biom.Table, DNAIterator):

--- a/q2_dada2/assets/run_dada_single.R
+++ b/q2_dada2/assets/run_dada_single.R
@@ -94,7 +94,7 @@ errQuit <- function(mesg, status=1) {
 
 ### VALIDATE ARGUMENTS ###
 
-# Input directory is expected to contain .fastq file(s)
+# Input directory is expected to contain .fastq.gz file(s)
 # that have not yet been filtered and globally trimmed
 # to the same length.
 if(!dir.exists(inp.dir)) {
@@ -189,9 +189,9 @@ seqtab <- makeSequenceTable(dds)
 # Remove chimeras
 cat("4) Remove chimeras (method = ", chimeraMethod, ")\n", sep="")
 if(chimeraMethod == "pooled") {
-  seqtab <- removeBimeraDenovo(seqtab, minFoldParentOverAbundance = minParentFold, multithread=multithread)
+  seqtab <- removeBimeraDenovo(seqtab, tableMethod=chimeraMethod, minFoldParentOverAbundance = minParentFold, multithread=multithread)
 } else if(chimeraMethod == "consensus") {
-  seqtab <- removeBimeraDenovo(seqtab, tableMethod="consensus", minFoldParentOverAbundance = minParentFold)
+  seqtab <- removeBimeraDenovo(seqtab, tableMethod=chimeraMethod, minFoldParentOverAbundance = minParentFold)
 }
 
 ### WRITE OUTPUT AND QUIT ###

--- a/q2_dada2/plugin_setup.py
+++ b/q2_dada2/plugin_setup.py
@@ -44,7 +44,7 @@ plugin.methods.register_function(
                 'max_ee': qiime2.plugin.Float,
                 'trunc_q': qiime2.plugin.Int,
                 'chimera_method': qiime2.plugin.Str %
-                                  qiime2.plugin.Choices(_CHIM_OPT),
+                qiime2.plugin.Choices(_CHIM_OPT),
                 'min_parent_abundance': qiime2.plugin.Float,
                 'n_threads': qiime2.plugin.Int,
                 'n_reads_learn': qiime2.plugin.Int,

--- a/q2_dada2/plugin_setup.py
+++ b/q2_dada2/plugin_setup.py
@@ -41,7 +41,8 @@ plugin.methods.register_function(
                 'trim_left': qiime2.plugin.Int,
                 'max_ee': qiime2.plugin.Float,
                 'trunc_q': qiime2.plugin.Int,
-                'chimera_method': qiime2.plugin.Str, # IS THIS THE RIGHT TYPE?
+                'chimera_method': qiime2.plugin.Str,
+                # IS qiime2.plugin.Str THE RIGHT TYPE?
                 'min_parent_abundance': qiime2.plugin.Float,
                 'n_threads': qiime2.plugin.Int,
                 'n_reads_learn': qiime2.plugin.Int,

--- a/q2_dada2/plugin_setup.py
+++ b/q2_dada2/plugin_setup.py
@@ -18,6 +18,8 @@ from q2_types.feature_table import FeatureTable, Frequency
 import q2_dada2
 from q2_dada2._plot import _PlotQualView
 
+_CHIM_OPT = {'pooled', 'consensus', 'none'}
+
 plugin = qiime2.plugin.Plugin(
     name='dada2',
     version=q2_dada2.__version__,
@@ -42,7 +44,7 @@ plugin.methods.register_function(
                 'max_ee': qiime2.plugin.Float,
                 'trunc_q': qiime2.plugin.Int,
                 'chimera_method': qiime2.plugin.Str %
-                    qiime2.plugin.Choices({'pooled', 'consensus', 'none'}),
+                                 qiime2.plugin.Choices(_CHIM_OPT),
                 'min_parent_abundance': qiime2.plugin.Float,
                 'n_threads': qiime2.plugin.Int,
                 'n_reads_learn': qiime2.plugin.Int,
@@ -120,7 +122,7 @@ plugin.methods.register_function(
                 'max_ee': qiime2.plugin.Float,
                 'trunc_q': qiime2.plugin.Int,
                 'chimera_method': qiime2.plugin.Str %
-                    qiime2.plugin.Choices({'pooled', 'consensus', 'none'}),
+                                 qiime2.plugin.Choices(_CHIM_OPT),
                 'min_parent_abundance': qiime2.plugin.Float,
                 'n_threads': qiime2.plugin.Int,
                 'n_reads_learn': qiime2.plugin.Int,

--- a/q2_dada2/plugin_setup.py
+++ b/q2_dada2/plugin_setup.py
@@ -41,8 +41,7 @@ plugin.methods.register_function(
                 'trim_left': qiime2.plugin.Int,
                 'max_ee': qiime2.plugin.Float,
                 'trunc_q': qiime2.plugin.Int,
-                'chimera_method': qiime2.plugin.Str,
-                # IS qiime2.plugin.Str THE RIGHT TYPE?
+                'chimera_method': qiime2.plugin.Str % qiime2.plugin.Choices({'pooled', 'consensus', 'none'}),
                 'min_parent_abundance': qiime2.plugin.Float,
                 'n_threads': qiime2.plugin.Int,
                 'n_reads_learn': qiime2.plugin.Int,
@@ -69,9 +68,9 @@ plugin.methods.register_function(
                     'score less than or equal to this value. If the resulting '
                     'read is then shorter than `trunc_len`, it is discarded.'),
         'chimera_method': ('The method used to remove chimeras. '
-                           'none: No chimera removal is performed. '
-                           'pooled: All reads are pooled prior to chimera '
-                           'detection. consensus: Chimeras are detected in '
+                           '"none": No chimera removal is performed. '
+                           '"pooled": All reads are pooled prior to chimera '
+                           'detection. "consensus": Chimeras are detected in '
                            'samples individually, and sequences found '
                            'chimeric in a sufficient fraction of samples are '
                            'removed.'),
@@ -119,8 +118,7 @@ plugin.methods.register_function(
                 'trim_left_r': qiime2.plugin.Int,
                 'max_ee': qiime2.plugin.Float,
                 'trunc_q': qiime2.plugin.Int,
-                'chimera_method': qiime2.plugin.Str,
-                # IS qiime2.plugin.Str THE RIGHT TYPE?
+                'chimera_method': qiime2.plugin.Str % qiime2.plugin.Choices({'pooled', 'consensus', 'none'}),
                 'min_parent_abundance': qiime2.plugin.Float,
                 'n_threads': qiime2.plugin.Int,
                 'n_reads_learn': qiime2.plugin.Int,
@@ -160,9 +158,9 @@ plugin.methods.register_function(
                     '(depending on the direction of the read) it is '
                     'discarded.'),
         'chimera_method': ('The method used to remove chimeras. '
-                           'none: No chimera removal is performed. '
-                           'pooled: All reads are pooled prior to chimera '
-                           'detection. consensus: Chimeras are detected in '
+                           '"none": No chimera removal is performed. '
+                           '"pooled": All reads are pooled prior to chimera '
+                           'detection. "consensus": Chimeras are detected in '
                            'samples individually, and sequences found '
                            'chimeric in a sufficient fraction of samples are '
                            'removed.'),

--- a/q2_dada2/plugin_setup.py
+++ b/q2_dada2/plugin_setup.py
@@ -41,6 +41,8 @@ plugin.methods.register_function(
                 'trim_left': qiime2.plugin.Int,
                 'max_ee': qiime2.plugin.Float,
                 'trunc_q': qiime2.plugin.Int,
+                'chimera_method': qiime2.plugin.Str, # IS THIS THE RIGHT TYPE?
+                'min_parent_abundance': qiime2.plugin.Float,
                 'n_threads': qiime2.plugin.Int,
                 'n_reads_learn': qiime2.plugin.Int,
                 'hashed_feature_ids': qiime2.plugin.Bool},
@@ -65,6 +67,16 @@ plugin.methods.register_function(
         'trunc_q': ('Reads are truncated at the first instance of a quality '
                     'score less than or equal to this value. If the resulting '
                     'read is then shorter than `trunc_len`, it is discarded.'),
+        'chimera_method': ('The method used to remove chimeras. Valid options... '
+                           'none: No chimera removal is performed. '
+                           'pooled: All reads are pooled prior to chimera detection. '
+                           'consensus: Chimeras are detect in samples individually, and
+                           'sequences found chimeric in a sufficient fraction of samples are removed.'),
+        'min_parent_abundance': ('The minimum abundance of potential "parents" of a sequence '
+                                 'being tested as chimeric, expressed as a fold-change versus '
+                                 'the abundance of the sequence being tested. Values should '
+                                 'be greater than or equal to 1 (i.e. parents should be more '
+                                 'abundant than the sequence being tested).'),
         'n_threads': ('The number of threads to use for multithreaded '
                       'processing. If 0 is provided, all available cores will '
                       'be used.'),
@@ -102,6 +114,8 @@ plugin.methods.register_function(
                 'trim_left_r': qiime2.plugin.Int,
                 'max_ee': qiime2.plugin.Float,
                 'trunc_q': qiime2.plugin.Int,
+                'chimera_method': qiime2.plugin.Str, # IS THIS THE RIGHT TYPE?
+                'min_parent_abundance': qiime2.plugin.Float,
                 'n_threads': qiime2.plugin.Int,
                 'n_reads_learn': qiime2.plugin.Int,
                 'hashed_feature_ids': qiime2.plugin.Bool},
@@ -139,6 +153,16 @@ plugin.methods.register_function(
                     'read is then shorter than `trunc_len_f` or `trunc_len_r` '
                     '(depending on the direction of the read) it is '
                     'discarded.'),
+        'chimera_method': ('The method used to remove chimeras. Valid options... '
+                           'none: No chimera removal is performed. '
+                           'pooled: All reads are pooled prior to chimera detection. '
+                           'consensus: Chimeras are detect in samples individually, and
+                           'sequences found chimeric in a sufficient fraction of samples are removed.'),
+        'min_parent_abundance': ('The minimum abundance of potential "parents" of a sequence '
+                                 'being tested as chimeric, expressed as a fold-change versus '
+                                 'the abundance of the sequence being tested. Values should '
+                                 'be greater than or equal to 1 (i.e. parents should be more '
+                                 'abundant than the sequence being tested).'),
         'n_threads': ('The number of threads to use for multithreaded '
                       'processing. If 0 is provided, all available cores will '
                       'be used.'),

--- a/q2_dada2/plugin_setup.py
+++ b/q2_dada2/plugin_setup.py
@@ -70,7 +70,7 @@ plugin.methods.register_function(
         'chimera_method': ('The method used to remove chimeras. Valid options... '
                            'none: No chimera removal is performed. '
                            'pooled: All reads are pooled prior to chimera detection. '
-                           'consensus: Chimeras are detect in samples individually, and
+                           'consensus: Chimeras are detect in samples individually, and '
                            'sequences found chimeric in a sufficient fraction of samples are removed.'),
         'min_parent_abundance': ('The minimum abundance of potential "parents" of a sequence '
                                  'being tested as chimeric, expressed as a fold-change versus '
@@ -156,7 +156,7 @@ plugin.methods.register_function(
         'chimera_method': ('The method used to remove chimeras. Valid options... '
                            'none: No chimera removal is performed. '
                            'pooled: All reads are pooled prior to chimera detection. '
-                           'consensus: Chimeras are detect in samples individually, and
+                           'consensus: Chimeras are detect in samples individually, and '
                            'sequences found chimeric in a sufficient fraction of samples are removed.'),
         'min_parent_abundance': ('The minimum abundance of potential "parents" of a sequence '
                                  'being tested as chimeric, expressed as a fold-change versus '

--- a/q2_dada2/plugin_setup.py
+++ b/q2_dada2/plugin_setup.py
@@ -67,15 +67,19 @@ plugin.methods.register_function(
         'trunc_q': ('Reads are truncated at the first instance of a quality '
                     'score less than or equal to this value. If the resulting '
                     'read is then shorter than `trunc_len`, it is discarded.'),
-        'chimera_method': ('The method used to remove chimeras. Valid options... '
+        'chimera_method': ('The method used to remove chimeras. '
                            'none: No chimera removal is performed. '
-                           'pooled: All reads are pooled prior to chimera detection. '
-                           'consensus: Chimeras are detect in samples individually, and '
-                           'sequences found chimeric in a sufficient fraction of samples are removed.'),
-        'min_parent_abundance': ('The minimum abundance of potential "parents" of a sequence '
-                                 'being tested as chimeric, expressed as a fold-change versus '
-                                 'the abundance of the sequence being tested. Values should '
-                                 'be greater than or equal to 1 (i.e. parents should be more '
+                           'pooled: All reads are pooled prior to chimera '
+                           'detection. consensus: Chimeras are detected in '
+                           'samples individually, and sequences found '
+                           'chimeric in a sufficient fraction of samples are '
+                           'removed.'),
+        'min_parent_abundance': ('The minimum abundance of potential parents '
+                                 'of a sequence being tested as chimeric, '
+                                 'expressed as a fold-change versus '
+                                 'the abundance of the sequence being tested. '
+                                 'Values should be greater than or equal to 1 '
+                                 '(i.e. parents should be more '
                                  'abundant than the sequence being tested).'),
         'n_threads': ('The number of threads to use for multithreaded '
                       'processing. If 0 is provided, all available cores will '
@@ -114,7 +118,8 @@ plugin.methods.register_function(
                 'trim_left_r': qiime2.plugin.Int,
                 'max_ee': qiime2.plugin.Float,
                 'trunc_q': qiime2.plugin.Int,
-                'chimera_method': qiime2.plugin.Str, # IS THIS THE RIGHT TYPE?
+                'chimera_method': qiime2.plugin.Str,
+                # IS qiime2.plugin.Str THE RIGHT TYPE?
                 'min_parent_abundance': qiime2.plugin.Float,
                 'n_threads': qiime2.plugin.Int,
                 'n_reads_learn': qiime2.plugin.Int,
@@ -153,15 +158,19 @@ plugin.methods.register_function(
                     'read is then shorter than `trunc_len_f` or `trunc_len_r` '
                     '(depending on the direction of the read) it is '
                     'discarded.'),
-        'chimera_method': ('The method used to remove chimeras. Valid options... '
+        'chimera_method': ('The method used to remove chimeras. '
                            'none: No chimera removal is performed. '
-                           'pooled: All reads are pooled prior to chimera detection. '
-                           'consensus: Chimeras are detect in samples individually, and '
-                           'sequences found chimeric in a sufficient fraction of samples are removed.'),
-        'min_parent_abundance': ('The minimum abundance of potential "parents" of a sequence '
-                                 'being tested as chimeric, expressed as a fold-change versus '
-                                 'the abundance of the sequence being tested. Values should '
-                                 'be greater than or equal to 1 (i.e. parents should be more '
+                           'pooled: All reads are pooled prior to chimera '
+                           'detection. consensus: Chimeras are detected in '
+                           'samples individually, and sequences found '
+                           'chimeric in a sufficient fraction of samples are '
+                           'removed.'),
+        'min_parent_abundance': ('The minimum abundance of potential parents '
+                                 'of a sequence being tested as chimeric, '
+                                 'expressed as a fold-change versus '
+                                 'the abundance of the sequence being tested. '
+                                 'Values should be greater than or equal to 1 '
+                                 '(i.e. parents should be more '
                                  'abundant than the sequence being tested).'),
         'n_threads': ('The number of threads to use for multithreaded '
                       'processing. If 0 is provided, all available cores will '

--- a/q2_dada2/plugin_setup.py
+++ b/q2_dada2/plugin_setup.py
@@ -44,7 +44,7 @@ plugin.methods.register_function(
                 'max_ee': qiime2.plugin.Float,
                 'trunc_q': qiime2.plugin.Int,
                 'chimera_method': qiime2.plugin.Str %
-                                 qiime2.plugin.Choices(_CHIM_OPT),
+                                  qiime2.plugin.Choices(_CHIM_OPT),
                 'min_parent_abundance': qiime2.plugin.Float,
                 'n_threads': qiime2.plugin.Int,
                 'n_reads_learn': qiime2.plugin.Int,
@@ -122,7 +122,7 @@ plugin.methods.register_function(
                 'max_ee': qiime2.plugin.Float,
                 'trunc_q': qiime2.plugin.Int,
                 'chimera_method': qiime2.plugin.Str %
-                                 qiime2.plugin.Choices(_CHIM_OPT),
+                qiime2.plugin.Choices(_CHIM_OPT),
                 'min_parent_abundance': qiime2.plugin.Float,
                 'n_threads': qiime2.plugin.Int,
                 'n_reads_learn': qiime2.plugin.Int,

--- a/q2_dada2/plugin_setup.py
+++ b/q2_dada2/plugin_setup.py
@@ -41,7 +41,8 @@ plugin.methods.register_function(
                 'trim_left': qiime2.plugin.Int,
                 'max_ee': qiime2.plugin.Float,
                 'trunc_q': qiime2.plugin.Int,
-                'chimera_method': qiime2.plugin.Str % qiime2.plugin.Choices({'pooled', 'consensus', 'none'}),
+                'chimera_method': qiime2.plugin.Str %
+                    qiime2.plugin.Choices({'pooled', 'consensus', 'none'}),
                 'min_parent_abundance': qiime2.plugin.Float,
                 'n_threads': qiime2.plugin.Int,
                 'n_reads_learn': qiime2.plugin.Int,
@@ -118,7 +119,8 @@ plugin.methods.register_function(
                 'trim_left_r': qiime2.plugin.Int,
                 'max_ee': qiime2.plugin.Float,
                 'trunc_q': qiime2.plugin.Int,
-                'chimera_method': qiime2.plugin.Str % qiime2.plugin.Choices({'pooled', 'consensus', 'none'}),
+                'chimera_method': qiime2.plugin.Str %
+                    qiime2.plugin.Choices({'pooled', 'consensus', 'none'}),
                 'min_parent_abundance': qiime2.plugin.Float,
                 'n_threads': qiime2.plugin.Int,
                 'n_reads_learn': qiime2.plugin.Int,


### PR DESCRIPTION
This pull request addresses #50 Two options were added.

`chimera-method`: valid options are `none`, `pooled` and `consensus` (where `pooled` is the current behavior).

`min-parent-abundance`: A numeric value which should be 1.0 or greater.

I've added the options to the R scripts and verified thy work. I also added in python code that passes the CI tests, but needs to be reviewed and probably fixed. The python side has not been tested. Possibly a test should be added as well?