### PR TITLE
Improved truncLen error message

### DIFF
--- a/q2_dada2/_denoise.py
+++ b/q2_dada2/_denoise.py
@@ -177,7 +177,10 @@ def denoise_paired(demultiplexed_seqs: SingleLanePerSamplePairedEndFastqDirFmt,
             if e.returncode == 2:
                 raise ValueError(
                     "No reads passed the filter. trunc_len_f (%r) or"
-                    " trunc_len_r (%r) may be longer than read lengths, or"
+                    " trunc_len_r (%r) may be individually longer than"
+                    " read lengths, or trunc_len_f + trunc_len_r may be"
+                    " shorter than the length of the amplicon + 20"
+                    " nucleotides (the length of the overlap). Alternatively,"
                     " other arguments (such as max_ee or trunc_q) may be"
                     " preventing reads from passing the filter."
                     % (trunc_len_f, trunc_len_r))

--- a/q2_dada2/plugin_setup.py
+++ b/q2_dada2/plugin_setup.py
@@ -136,7 +136,9 @@ plugin.methods.register_function(
                         'the 3\' end of the of the input sequences, which '
                         'will be the bases that were sequenced in the last '
                         'cycles. Reads that are shorter than this value '
-                        'will be discarded.'),
+                        'will be discarded. After this parameter is applied '
+                        'there must still be at least a 20 nucleotide overlap '
+                        'between the forward and reverse reads.'),
         'trim_left_f': ('Position at which forward read sequences should be '
                         'trimmed due to low quality. This trims the 5\' end '
                         'of the input sequences, which will be the bases that '
@@ -146,7 +148,9 @@ plugin.methods.register_function(
                         'the 3\' end of the of the input sequences, which '
                         'will be the bases that were sequenced in the last '
                         'cycles. Reads that are shorter than this value '
-                        'will be discarded.'),
+                        'will be discarded. After this parameter is applied '
+                        'there must still be at least a 20 nucleotide overlap '
+                        'between the forward and reverse reads.'),
         'trim_left_r': ('Position at which reverse read sequences should be '
                         'trimmed due to low quality. This trims the 5\' end '
                         'of the input sequences, which will be the bases that '


### PR DESCRIPTION
This PR addresses issue #52 

The new (hopefully improved) error message from `denoise_paired` in the event that `run_dada_paired.R` fails says the following:

````PYTHON
raise ValueError(
                    "No reads passed the filter. trunc_len_f (%r) or"
                    " trunc_len_r (%r) may be individually longer than"
                    " read lengths, or trunc_len_f + trunc_len_r may be"
                    " shorter than the length of the amplicon + 20"
                    " nucleotides (the length of the overlap). Alternatively,"
                    " other arguments (such as max_ee or trunc_q) may be"
                    " preventing reads from passing the filter."
                    % (trunc_len_f, trunc_len_r))
````