### PR TITLE
ENH: prettier error with return code

### DIFF
--- a/q2_dada2/_denoise.py
+++ b/q2_dada2/_denoise.py
@@ -130,7 +130,9 @@ def denoise_single(demultiplexed_seqs: SingleLanePerSampleSingleEndFastqDirFmt,
                     " or trunc_q) may be preventing reads from passing the"
                     " filter." % trunc_len)
             else:
-                raise
+                raise Exception("An error was encountered while running DADA2"
+                                " in R (return code %d), please inspect stdout"
+                                " and stderr to learn more." % e.returncode)
         return _denoise_helper(biom_fp, hashed_feature_ids)
 
 
@@ -185,5 +187,7 @@ def denoise_paired(demultiplexed_seqs: SingleLanePerSamplePairedEndFastqDirFmt,
                     " preventing reads from passing the filter."
                     % (trunc_len_f, trunc_len_r))
             else:
-                raise
+                raise Exception("An error was encountered while running DADA2"
+                                " in R (return code %d), please inspect stdout"
+                                " and stderr to learn more." % e.returncode)
         return _denoise_helper(biom_fp, hashed_feature_ids)


### PR DESCRIPTION
I'm not in love with this, but it's at least a bit cleaner. There isn't really a good way to test this either (I had to sit in my `/tmp` dir and delete files to test). It would be nice if we could mention `verbose` but that's really a implementation detail of q2cli and so it wouldn't make sense for the studio or artifact api.

I'm good with also just closing this PR and leaving as is.