### PR TITLE
Update DADA2 1.8.0

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -21,11 +21,7 @@ requirements:
     - python 3.5*
     - setuptools
     - biom-format >=2.1.5,<2.2.0
-    # This pin only exists because namespaces where shuffled around and the
-    # next bioconductor version was uploaded only on OS X and only for
-    # biostrings at the moment.
-    - bioconductor-biostrings 2.48.0
-    - bioconductor-dada2 1.6.0 r3.4.1_0
+    - bioconductor-dada2 1.8.0
     # openjdk is not a real dependency, but, r-base has a post-link and post-
     # activation hook that calls R CMD javareconf, which pokes around for any
     # installations of java. On modern versions of macOS, a binary called


### PR DESCRIPTION
It looks like an OS X build was pushed for 2.48.0 (but not for linux).
Since bioconda doesn't have a way to synchronize the bionconductor
packages the bionconductor-dada2 package is pulling in the latest
biostrings which won't work as that package hasn't been rebuilt yet with
the namespace changes found here:

https://github.com/benjjneb/dada2/commit/85846e89bce8970a920bb492ae5108e79b8ab395#diff-7347fe5a0f184f79ef064e92e3beb297


This should fix https://busywork.qiime2.org/teams/main/pipelines/master-distribution/jobs/integration/builds/16 in the interim.