### PR TITLE
HACK: pin biostrings

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     # This pin only exists because namespaces where shuffled around and the
     # next bioconductor version was uploaded only on OS X and only for
     # biostrings at the moment.
-    - bioconductor-biostrings 2.48.0
+    - bioconductor-biostrings 2.46.0
     - bioconductor-dada2 1.6.0 r3.4.1_0
     # openjdk is not a real dependency, but, r-base has a post-link and post-
     # activation hook that calls R CMD javareconf, which pokes around for any


### PR DESCRIPTION
Pinned the wrong version in the last revert commit in the repo.