### PR TITLE
Update to dada2 1.8.0; drop osx pins

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -19,27 +19,8 @@ requirements:
 
   run:
     - python {{ python }}
-    - biom-format >=2.1.5,<2.2.0
-    # These pins only exist because namespaces where shuffled around and the
-    # next bioconductor version was uploaded only on OS X and only for
-    # biostrings at the moment.
-    - bioconductor-biobase 2.38.0
-    - bioconductor-biocgenerics 0.24.0
-    - bioconductor-biocparallel 1.12.0
-    - bioconductor-biostrings 2.46.0
-    - bioconductor-dada2 1.6.0 r3.4.1_0
-    - bioconductor-delayedarray 0.4.1
-    - bioconductor-genomeinfodb 1.14.0
-    - bioconductor-genomeinfodbdata 1.0.0
-    - bioconductor-genomicalignments 1.14.1
-    - bioconductor-genomicranges 1.30.3
-    - bioconductor-iranges 2.12.0
-    - bioconductor-rsamtools 1.30.0
-    - bioconductor-s4vectors 0.16.0
-    - bioconductor-shortread 1.36.0
-    - bioconductor-summarizedexperiment 1.8.0
-    - bioconductor-xvector 0.18.0
-    - bioconductor-zlibbioc 1.24.0
+    - biom-format >=2.1.5,<2.2.0a0
+    - bioconductor-dada2 >=1.8.0,<1.9a0
     # openjdk is not a real dependency, but, r-base has a post-link and post-
     # activation hook that calls R CMD javareconf, which pokes around for any
     # installations of java. On modern versions of macOS, a binary called

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -19,8 +19,8 @@ requirements:
 
   run:
     - python {{ python }}
-    - biom-format >=2.1.5,<2.2.0a0
-    - bioconductor-dada2 >=1.8.0,<1.9a0
+    - biom-format >=2.1.5,<2.2a0
+    - bioconductor-dada2 >=1.6.0,<1.7a0
     # openjdk is not a real dependency, but, r-base has a post-link and post-
     # activation hook that calls R CMD javareconf, which pokes around for any
     # installations of java. On modern versions of macOS, a binary called


### PR DESCRIPTION
BTW: `1.2.0a0` is `<` than `1.2.0`, so pinning should use `>=1.1.23,<1.2a0` or similar. Just in case someone pushes alphas.

If in doubt, use 

```
from conda.exports import VersionOrder
[str(x) for x in sorted(VersionOrder(v) for v in 
('1.2.0', '1.2.0a0', '1.2a0', '1.2', '1.1.99', '1.2.1', 
'1.2p1', '1.2post0', '1.2.12', '1.2.0.post0', '1.2.p0'))]
```

```
['1.1.99', '1.2a0', '1.2p1', '1.2.0a0', '1.2.p0', '1.2.0', 
'1.2', '1.2.0.post0', '1.2.1', '1.2.12', '1.2post0']
```

to verify what will actually happen. It's mostly PEP440 but not completely so, and not really intuitive (but then the intuition on that topic varies). 

I really like `1.2.0 < 1.2 < 1.2.1` ...