### PR TITLE
Support allowOneOff option in removeBineraDenovo()

### DIFF
--- a/q2_dada2/_denoise.py
+++ b/q2_dada2/_denoise.py
@@ -52,6 +52,8 @@ _POOL_STR = (lambda x: x in {'pseudo', 'independent'},
              'pseudo or independent')
 _CHIM_STR = (lambda x: x in {'pooled', 'consensus', 'none'},
              'pooled, consensus or none')
+_BOOLEAN = (lambda x: type(x) is bool,
+             'True or False')
 # Better to choose to skip, than to implicitly ignore things that KeyError
 _SKIP = (lambda x: True, '')
 _valid_inputs = {
@@ -70,6 +72,7 @@ _valid_inputs = {
     'pooling_method': _POOL_STR,
     'chimera_method': _CHIM_STR,
     'min_fold_parent_over_abundance': _NAT_NUM,
+    'allow_one_off': _BOOLEAN,
     'n_threads': _WHOLE_NUM,
     # 0 is technically allowed, but we don't want to support it because it only
     # takes all reads from the first sample (alphabetically by sample id)
@@ -155,7 +158,7 @@ def _denoise_helper(biom_fp, track_fp, hashed_feature_ids):
 # sure that DADA2 is able to do what it needs to do.
 def _denoise_single(demultiplexed_seqs, trunc_len, trim_left, max_ee, trunc_q,
                     max_len, pooling_method, chimera_method,
-                    min_fold_parent_over_abundance,
+                    min_fold_parent_over_abundance, allow_one_off,
                     n_threads, n_reads_learn, hashed_feature_ids,
                     homopolymer_gap_penalty, band_size):
     _check_inputs(**locals())
@@ -175,7 +178,9 @@ def _denoise_single(demultiplexed_seqs, trunc_len, trim_left, max_ee, trunc_q,
                str(demultiplexed_seqs), biom_fp, track_fp, temp_dir_name,
                str(trunc_len), str(trim_left), str(max_ee), str(trunc_q),
                str(max_len), str(pooling_method), str(chimera_method),
-               str(min_fold_parent_over_abundance), str(n_threads),
+               str(min_fold_parent_over_abundance), 
+               str(allow_one_off),
+               str(n_threads),
                str(n_reads_learn), str(homopolymer_gap_penalty),
                str(band_size)]
         try:
@@ -199,6 +204,7 @@ def denoise_single(demultiplexed_seqs: SingleLanePerSampleSingleEndFastqDirFmt,
                    trunc_q: int = 2, pooling_method: str = 'independent',
                    chimera_method: str = 'consensus',
                    min_fold_parent_over_abundance: float = 1.0,
+                   allow_one_off: bool = False,
                    n_threads: int = 1, n_reads_learn: int = 1000000,
                    hashed_feature_ids: bool = True
                    ) -> (biom.Table, DNAIterator, qiime2.Metadata):
@@ -212,6 +218,7 @@ def denoise_single(demultiplexed_seqs: SingleLanePerSampleSingleEndFastqDirFmt,
         pooling_method=pooling_method,
         chimera_method=chimera_method,
         min_fold_parent_over_abundance=min_fold_parent_over_abundance,
+        allow_one_off=allow_one_off,
         n_threads=n_threads,
         n_reads_learn=n_reads_learn,
         hashed_feature_ids=hashed_feature_ids,
@@ -227,6 +234,7 @@ def denoise_paired(demultiplexed_seqs: SingleLanePerSamplePairedEndFastqDirFmt,
                    pooling_method: str = 'independent',
                    chimera_method: str = 'consensus',
                    min_fold_parent_over_abundance: float = 1.0,
+                   allow_one_off: bool = False,
                    n_threads: int = 1, n_reads_learn: int = 1000000,
                    hashed_feature_ids: bool = True
                    ) -> (biom.Table, DNAIterator, qiime2.Metadata):
@@ -261,6 +269,7 @@ def denoise_paired(demultiplexed_seqs: SingleLanePerSamplePairedEndFastqDirFmt,
                str(max_ee_f), str(max_ee_r), str(trunc_q),
                str(min_overlap), str(pooling_method),
                str(chimera_method), str(min_fold_parent_over_abundance),
+               str(allow_one_off),
                str(n_threads), str(n_reads_learn)]
         try:
             run_commands([cmd])
@@ -288,6 +297,7 @@ def denoise_pyro(demultiplexed_seqs: SingleLanePerSampleSingleEndFastqDirFmt,
                  pooling_method: str = 'independent',
                  chimera_method: str = 'consensus',
                  min_fold_parent_over_abundance: float = 1.0,
+                 allow_one_off: bool = False,
                  n_threads: int = 1, n_reads_learn: int = 250000,
                  hashed_feature_ids: bool = True
                  ) -> (biom.Table, DNAIterator, qiime2.Metadata):
@@ -301,6 +311,7 @@ def denoise_pyro(demultiplexed_seqs: SingleLanePerSampleSingleEndFastqDirFmt,
         pooling_method=pooling_method,
         chimera_method=chimera_method,
         min_fold_parent_over_abundance=min_fold_parent_over_abundance,
+        allow_one_off=allow_one_off,
         n_threads=n_threads,
         n_reads_learn=n_reads_learn,
         hashed_feature_ids=hashed_feature_ids,

--- a/q2_dada2/assets/run_dada_paired.R
+++ b/q2_dada2/assets/run_dada_paired.R
@@ -8,7 +8,7 @@
 # table. It is intended for use with the QIIME2 plugin
 # for DADA2.
 #
-# Rscript run_dada_paired.R input_dirF input_dirR output.tsv track.tsv filtered_dirF filtered_dirR 240 160 0 0 2.0 2.0 2 12 independent pooled 1.0 0 100000
+# Rscript run_dada_paired.R input_dirF input_dirR output.tsv track.tsv filtered_dirF filtered_dirR 240 160 0 0 2.0 2.0 2 12 independent pooled 1.0 True 0 100000
 ####################################################
 
 ####################################################
@@ -107,13 +107,18 @@
 #               abundant than the sequence being tested).
 #    Ex: 1.0
 #
+# 18) allowOneOff - Bimeras that are one-off from exact are also identified if the allowOneOff
+#               argument is TRUE. If FALSE, a sequence will be identified as bimera if it is one 
+#               mismatch or indel away from an exact bimera.
+#    Ex: FALSE
+#
 ### SPEED ARGUMENTS ###
 #
-# 18) nthreads - The number of threads to use.
+# 19) nthreads - The number of threads to use.
 #                 Special values: 0 - detect available and use all.
 #    Ex: 1
 #
-# 19) nreads_learn - The minimum number of reads to learn the error model from.
+# 20) nreads_learn - The minimum number of reads to learn the error model from.
 #                 Special values: 0 - Use all input reads.
 #    Ex: 1000000
 #
@@ -141,8 +146,9 @@ minOverlap <- as.integer(args[14])
 poolMethod <- args[[15]]
 chimeraMethod <- args[[16]]
 minParentFold <- as.numeric(args[[17]])
-nthreads <- as.integer(args[[18]])
-nreads.learn <- as.integer(args[[19]])
+allowOneOff <- as.logical(args[[18]])
+nthreads <- as.integer(args[[19]])
+nreads.learn <- as.integer(args[[20]])
 
 ### VALIDATE ARGUMENTS ###
 
@@ -273,7 +279,7 @@ seqtab <- makeSequenceTable(mergers)
 # Remove chimeras
 cat("4) Remove chimeras (method = ", chimeraMethod, ")\n", sep="")
 if(chimeraMethod %in% c("pooled", "consensus")) {
-  seqtab.nochim <- removeBimeraDenovo(seqtab, method=chimeraMethod, minFoldParentOverAbundance=minParentFold, multithread=multithread)
+  seqtab.nochim <- removeBimeraDenovo(seqtab, method=chimeraMethod, minFoldParentOverAbundance=minParentFold, allowOneOff=allowOneOff, multithread=multithread)
 } else { # No chimera removal, copy seqtab to seqtab.nochim
   seqtab.nochim <- seqtab
 }

--- a/q2_dada2/assets/run_dada_paired.R
+++ b/q2_dada2/assets/run_dada_paired.R
@@ -8,7 +8,7 @@
 # table. It is intended for use with the QIIME2 plugin
 # for DADA2.
 #
-# Rscript run_dada_paired.R input_dirF input_dirR output.tsv track.tsv filtered_dirF filtered_dirR 240 160 0 0 2.0 2 pooled 1.0 0 100000
+# Rscript run_dada_paired.R input_dirF input_dirR output.tsv track.tsv filtered_dirF filtered_dirR 240 160 0 0 2.0 2.0 2 12 independent pooled 1.0 0 100000
 ####################################################
 
 ####################################################
@@ -75,9 +75,17 @@
 #                If the read is then shorter than truncLen, it is discarded.
 #    Ex: 2
 #
+#
+### PAIRS MERGING ARGUMENTS ###
+#
+# 14) minOverlap - The minimum length of the overlap required for merging
+#                the forward and reverse reads.
+#    Ex: 12
+#
+#
 ### SENSITIVITY ARGUMENTS ###
 #
-# 14) poolMethod - The method used to pool (or not) samples during denoising.
+# 15) poolMethod - The method used to pool (or not) samples during denoising.
 #             Valid options are:
 #               independent: (Default) No pooling, samples are denoised indpendently.
 #               pseudo: Samples are "pseudo-pooled" for denoising.
@@ -86,14 +94,14 @@
 #
 ### CHIMERA ARGUMENTS ###
 #
-# 15) chimeraMethod - The method used to remove chimeras. Valid options are:
+# 16) chimeraMethod - The method used to remove chimeras. Valid options are:
 #               none: No chimera removal is performed.
 #               pooled: All reads are pooled prior to chimera detection.
 #               consensus: Chimeras are detect in samples individually, and a consensus decision
 #                           is made for each sequence variant.
 #    Ex: consensus
 #
-# 16) minParentFold - The minimum abundance of potential "parents" of a sequence being
+# 17) minParentFold - The minimum abundance of potential "parents" of a sequence being
 #               tested as chimeric, expressed as a fold-change versus the abundance of the sequence being
 #               tested. Values should be greater than or equal to 1 (i.e. parents should be more
 #               abundant than the sequence being tested).
@@ -101,11 +109,11 @@
 #
 ### SPEED ARGUMENTS ###
 #
-# 17) nthreads - The number of threads to use.
+# 18) nthreads - The number of threads to use.
 #                 Special values: 0 - detect available and use all.
 #    Ex: 1
 #
-# 18) nreads_learn - The minimum number of reads to learn the error model from.
+# 19) nreads_learn - The minimum number of reads to learn the error model from.
 #                 Special values: 0 - Use all input reads.
 #    Ex: 1000000
 #

--- a/q2_dada2/assets/run_dada_single.R
+++ b/q2_dada2/assets/run_dada_single.R
@@ -6,7 +6,7 @@
 # table. It is intended for use with the QIIME2 plugin
 # for DADA2.
 #
-# Ex: Rscript run_dada_single.R input_dir output.tsv track.tsv filtered_dir 200 0 2.0 2 Inf pooled 1.0 0 1000000 NULL 32
+# Ex: Rscript run_dada_single.R input_dir output.tsv track.tsv filtered_dir 200 0 2.0 2 Inf independent pooled 1.0 TRUE 0 1000000 NULL 32
 ####################################################
 
 ####################################################
@@ -79,6 +79,12 @@
 #               abundant than the sequence being tested).
 #    Ex: 1.0
 #
+# 13) allowOneOff - Bimeras that are one-off from exact are also identified if the allowOneOff
+#               argument is TRUE. If FALSE, a sequence will be identified as bimera if it is one 
+#               mismatch or indel away from an exact bimera.
+#    Ex: FALSE
+#
+#
 ### SPEED ARGUMENTS ###
 #
 # 13) nthreads - The number of threads to use.
@@ -88,6 +94,7 @@
 # 14) nreads_learn - The minimum number of reads to learn the error model from.
 #                 Special values: 0 - Use all input reads.
 #    Ex: 1000000
+#
 #
 ### GLOBAL OPTION ARGUMENTS ###
 #
@@ -119,12 +126,13 @@ maxLen <- as.numeric(args[[9]]) # Allows Inf
 poolMethod <- args[[10]]
 chimeraMethod <- args[[11]]
 minParentFold <- as.numeric(args[[12]])
-nthreads <- as.integer(args[[13]])
-nreads.learn <- as.integer(args[[14]])
+allowOneOff <- as.logical(args[[13]])
+nthreads <- as.integer(args[[14]])
+nreads.learn <- as.integer(args[[15]])
 # The following args are not directly exposed to end users in q2-dada2,
 # but rather indirectly, via the methods `denoise-single` and `denoise-pyro`.
-HOMOPOLYMER_GAP_PENALTY <- if (args[[15]]=='NULL') NULL else as.integer(args[[15]])
-BAND_SIZE <- as.integer(args[[16]])
+HOMOPOLYMER_GAP_PENALTY <- if (args[[16]]=='NULL') NULL else as.integer(args[[15]])
+BAND_SIZE <- as.integer(args[[17]])
 
 ### VALIDATE ARGUMENTS ###
 
@@ -227,7 +235,7 @@ seqtab <- makeSequenceTable(dds)
 ### Remove chimeras
 cat("4) Remove chimeras (method = ", chimeraMethod, ")\n", sep="")
 if(chimeraMethod %in% c("pooled", "consensus")) {
-  seqtab.nochim <- removeBimeraDenovo(seqtab, method=chimeraMethod, minFoldParentOverAbundance=minParentFold, multithread=multithread)
+  seqtab.nochim <- removeBimeraDenovo(seqtab, method=chimeraMethod, minFoldParentOverAbundance=minParentFold, allowOneOff=allowOneOff, multithread=multithread)
 } else { # No chimera removal, copy seqtab to seqtab.nochim
   seqtab.nochim <- seqtab
 }

--- a/q2_dada2/plugin_setup.py
+++ b/q2_dada2/plugin_setup.py
@@ -46,6 +46,7 @@ plugin.methods.register_function(
                 'chimera_method': qiime2.plugin.Str %
                 qiime2.plugin.Choices(_CHIM_OPT),
                 'min_fold_parent_over_abundance': qiime2.plugin.Float,
+                'allow_one_off': qiime2.plugin.Bool,
                 'n_threads': qiime2.plugin.Int,
                 'n_reads_learn': qiime2.plugin.Int,
                 'hashed_feature_ids': qiime2.plugin.Bool},
@@ -98,6 +99,11 @@ plugin.methods.register_function(
             'than or equal to 1 (i.e. parents should be more abundant than '
             'the sequence being tested). This parameter has no effect if '
             'chimera_method is "none".'),
+        'allow_one_off': (
+            'Bimeras that are one-off from exact are also '
+            'identified if the allowOneOff argument is TRUE.'
+            'If FALSE, a sequence will be identified as bimera if it is one '
+            'mismatch or indel away from an exact bimera.'),
         'n_threads': ('The number of threads to use for multithreaded '
                       'processing. If 0 is provided, all available cores will '
                       'be used.'),
@@ -143,6 +149,7 @@ plugin.methods.register_function(
                 'chimera_method': qiime2.plugin.Str %
                 qiime2.plugin.Choices(_CHIM_OPT),
                 'min_fold_parent_over_abundance': qiime2.plugin.Float,
+                'allow_one_off': qiime2.plugin.Bool,
                 'n_threads': qiime2.plugin.Int,
                 'n_reads_learn': qiime2.plugin.Int,
                 'hashed_feature_ids': qiime2.plugin.Bool},
@@ -216,6 +223,11 @@ plugin.methods.register_function(
             'than or equal to 1 (i.e. parents should be more abundant than '
             'the sequence being tested). This parameter has no effect if '
             'chimera_method is "none".'),
+        'allow_one_off': (
+            'Bimeras that are one-off from exact are also '
+            'identified if the allowOneOff argument is TRUE.'
+            'If FALSE, a sequence will be identified as bimera if it is one '
+            'mismatch or indel away from an exact bimera.'),
         'n_threads': ('The number of threads to use for multithreaded '
                       'processing. If 0 is provided, all available cores will '
                       'be used.'),
@@ -259,6 +271,7 @@ plugin.methods.register_function(
                 'chimera_method': qiime2.plugin.Str %
                 qiime2.plugin.Choices(_CHIM_OPT),
                 'min_fold_parent_over_abundance': qiime2.plugin.Float,
+                'allow_one_off': qiime2.plugin.Bool,
                 'n_threads': qiime2.plugin.Int,
                 'n_reads_learn': qiime2.plugin.Int,
                 'hashed_feature_ids': qiime2.plugin.Bool},
@@ -313,6 +326,11 @@ plugin.methods.register_function(
             'than or equal to 1 (i.e. parents should be more abundant than '
             'the sequence being tested). This parameter has no effect if '
             'chimera_method is "none".',
+        'allow_one_off': (
+            'Bimeras that are one-off from exact are also '
+            'identified if the allowOneOff argument is True. '
+            'If False, a sequence will be identified as bimera if it is one '
+            'mismatch or indel away from an exact bimera.'),
         'n_threads': 'The number of threads to use for multithreaded '
                      'processing. If 0 is provided, all available cores will '
                      'be used.',


### PR DESCRIPTION
Support of the `allowOneOff` argument in the `runBimeraDenovo()` function, which enables the user to allow for one mismatch or indel in bimera detection when set to `True` (default = `False`).
An example of the impact of this parameter is described in benjjneb/dada2#610.
Resolves #126.

Took the opportunity to correct the parameters description & order and command example in the header of the R scripts.

(Note: this is my first pull request ever so hopefully I did everything properly😊 )
