### PR TITLE
dep: adding r-base

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -19,8 +19,7 @@ requirements:
   run:
     - python {{ python }}
     - biom-format {{ biom_format }}
-    - bioconductor-dada2 1.22.0
-    - r-base >=4.2.0
+    - r-base {{ r-base }}
     - r-optparse >=1.7.1
     # openjdk is not a real dependency, but, r-base has a post-link and post-
     # activation hook that calls R CMD javareconf, which pokes around for any

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - python {{ python }}
     - biom-format {{ biom_format }}
     - bioconductor-dada2 1.22.0
+    - r-base >=4.2.0
     - r-optparse >=1.7.1
     # openjdk is not a real dependency, but, r-base has a post-link and post-
     # activation hook that calls R CMD javareconf, which pokes around for any

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -19,7 +19,8 @@ requirements:
   run:
     - python {{ python }}
     - biom-format {{ biom_format }}
-    - r-base {{ r-base }}
+    - bioconductor-dada2
+    - r-base {{ r_base }}
     - r-optparse >=1.7.1
     # openjdk is not a real dependency, but, r-base has a post-link and post-
     # activation hook that calls R CMD javareconf, which pokes around for any

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   run:
     - python {{ python }}
     - biom-format {{ biom_format }}
-    - r-base {{ r_base }}
+    - r-base {{ r-base }}
     - r-optparse >=1.7.1
     # openjdk is not a real dependency, but, r-base has a post-link and post-
     # activation hook that calls R CMD javareconf, which pokes around for any


### PR DESCRIPTION
this PR min pins r-base to keep dada2 up to date with the global r-base requirement in package integration.