### PR TITLE
maint: increase trunc length for smaller demux input

### DIFF
--- a/q2_dada2/_examples.py
+++ b/q2_dada2/_examples.py
@@ -43,8 +43,8 @@ def denoise_paired(use):
         use.UsageAction('dada2', 'denoise_paired'),
         use.UsageInputs(
             demultiplexed_seqs=demux_paired,
-            trunc_len_f=120,
-            trunc_len_r=120,
+            trunc_len_f=150,
+            trunc_len_r=140,
         ),
         use.UsageOutputNames(
             representative_sequences='representative_sequences',

--- a/q2_dada2/plugin_setup.py
+++ b/q2_dada2/plugin_setup.py
@@ -131,8 +131,7 @@ plugin.methods.register_function(
     description=('This method denoises single-end sequences, dereplicates '
                  'them, and filters chimeras.'),
     examples={
-        'denoise_single': ex.denoise_single,
-        'denoise_paired': ex.denoise_paired
+        'denoise_single': ex.denoise_single
     }
 )
 
@@ -259,7 +258,10 @@ plugin.methods.register_function(
     },
     name='Denoise and dereplicate paired-end sequences',
     description=('This method denoises paired-end sequences, dereplicates '
-                 'them, and filters chimeras.')
+                 'them, and filters chimeras.'),
+    examples={
+        'denoise_paired': ex.denoise_paired
+    }
 )
 
 


### PR DESCRIPTION
This PR updates the truncation length for both forward and reverse reads in the `denoise-paired` usage example.

Some of our usage example data exceeded Github's 10MB file size limit - thus requiring the input demux file for this example to be subsampled to 10% of it's original size. With this smaller demux file, both forward and reverse truncation lengths needed to be increased.

Additionally, I noticed that I had unintentionally added both `denoise-single` and `denoise-paired` examples under the plugin registration for `denoise-single`, so the `denoise-paired` example has been moved to the `denoise-paired` method registration.