### PR TITLE
BUG: Empty samples

### DIFF
--- a/q2_dada2/_denoise.py
+++ b/q2_dada2/_denoise.py
@@ -178,7 +178,7 @@ def _denoise_helper(biom_fp, track_fp, hashed_feature_ids, retain_all_samples,
         table_to_add = biom.Table(np.zeros((len(table_cols), len(table_rows))),
                                   table_cols, table_rows, type="OTU table")
         table = table.concat(table_to_add)
-    # This is necissary (instead of just not reintroducing above)
+    # This is necessary (instead of just not reintroducing above)
     # dada2 will discard samples which are empty after filtering
     # but will keep samples that are empty after merging
     # so there are potentially samples removed here that were not

--- a/q2_dada2/_denoise.py
+++ b/q2_dada2/_denoise.py
@@ -172,10 +172,12 @@ def _denoise_helper(biom_fp, track_fp, hashed_feature_ids, retain_all_samples,
     # Reintroduce empty samples dropped by dada2.
     table_cols = table.ids(axis='observation')
     table_rows = list(set(df.index) - set(table.ids()))
-    table_to_add = biom.Table(np.zeros((len(table_cols), len(table_rows))),
-                              table_cols, table_rows,
-                              type="OTU table")
-    table = table.concat(table_to_add)
+
+    # We only want to do this if something was actually dropped
+    if table_rows:
+        table_to_add = biom.Table(np.zeros((len(table_cols), len(table_rows))),
+                                  table_cols, table_rows, type="OTU table")
+        table = table.concat(table_to_add)
     # This is necissary (instead of just not reintroducing above)
     # dada2 will discard samples which are empty after filtering
     # but will keep samples that are empty after merging


### PR DESCRIPTION
We attempt to concatenate the empty samples dropped by dada2 in R back onto the table. If no samples are dropped we attempt to concat an empty 0x0 table onto the table produced by dada2 in R.

Bug introduced [here](https://github.com/qiime2/q2-dada2/pull/139)

Came up on the forum [here](https://forum.qiime2.org/t/mismatching-dimensions-along-axis-0-0-1-in-dada2-plugin/30915)

Should be resolved by ensuring we have dropped samples before attempting to concat them back on.

OK so I went down a bit of a rabbit hole here, and the explanation is not actually as simple as I originally believed. The user on the forum specifically has 1 OTU and no dropped samples, so we try to instantiate a 1x0 biom table. We end up with a 0x0 biom table because of [this](https://github.com/biocore/biom-format/blame/0692d2f3d6dfdad9d653ca21f46a50235d10981d/biom/table.py#L5419) line of code here. The guard I implemented in this PR should still work, but not quite for the reason I thought.
