### PR TITLE
DOC: clarify n_reads_learn help text

### DIFF
--- a/q2_dada2/plugin_setup.py
+++ b/q2_dada2/plugin_setup.py
@@ -123,9 +123,10 @@ plugin.methods.register_function(
                       'processing. If 0 is provided, all available cores will '
                       'be used.'),
         'n_reads_learn': ('The number of reads to use when training the '
-                          'error model. Smaller numbers will result in a '
-                          'shorter run time but a less reliable error '
-                          'model.'),
+                          'error model. This is passed to DADA2 as the '
+                          '`nreads` argument to `learnErrors`. Smaller '
+                          'numbers will result in a shorter run time but a '
+                          'less reliable error model.'),
         'hashed_feature_ids': ('If true, the feature ids in the resulting '
                                'table will be presented as hashes of the '
                                'sequences defining each feature. The hash '
@@ -269,9 +270,10 @@ plugin.methods.register_function(
                       'processing. If 0 is provided, all available cores will '
                       'be used.'),
         'n_reads_learn': ('The number of reads to use when training the '
-                          'error model. Smaller numbers will result in a '
-                          'shorter run time but a less reliable error '
-                          'model.'),
+                          'error model. This is passed to DADA2 as the '
+                          '`nreads` argument to `learnErrors`. Smaller '
+                          'numbers will result in a shorter run time but a '
+                          'less reliable error model.'),
         'hashed_feature_ids': ('If true, the feature ids in the resulting '
                                'table will be presented as hashes of the '
                                'sequences defining each feature. The hash '
@@ -382,9 +384,10 @@ plugin.methods.register_function(
                      'processing. If 0 is provided, all available cores will '
                      'be used.',
         'n_reads_learn': 'The number of reads to use when training the '
-                         'error model. Smaller numbers will result in a '
-                         'shorter run time but a less reliable error '
-                         'model.',
+                         'error model. This is passed to DADA2 as the '
+                         '`nreads` argument to `learnErrors`. Smaller '
+                         'numbers will result in a shorter run time but a '
+                         'less reliable error model.',
         'hashed_feature_ids': 'If true, the feature ids in the resulting '
                               'table will be presented as hashes of the '
                               'sequences defining each feature. The hash '
@@ -520,8 +523,10 @@ plugin.methods.register_function(
                      'processing. If 0 is provided, all available cores will '
                      'be used.',
         'n_reads_learn': 'The number of reads to use when training the '
-                         'error model. Smaller numbers will result in a '
-                         'shorter run time but a less reliable error model.',
+                         'error model. This is passed to DADA2 as the '
+                         '`nreads` argument to `learnErrors`. Smaller '
+                         'numbers will result in a shorter run time but a '
+                         'less reliable error model.',
         'hashed_feature_ids': 'If true, the feature ids in the resulting '
                               'table will be presented as hashes of the '
                               'sequences defining each feature. The hash '

--- a/q2_dada2/plugin_setup.py
+++ b/q2_dada2/plugin_setup.py
@@ -122,11 +122,11 @@ plugin.methods.register_function(
         'n_threads': ('The number of threads to use for multithreaded '
                       'processing. If 0 is provided, all available cores will '
                       'be used.'),
-        'n_reads_learn': ('The number of reads to use when training the '
-                          'error model. This is passed to DADA2 as the '
-                          '`nreads` argument to `learnErrors`. Smaller '
-                          'numbers will result in a shorter run time but a '
-                          'less reliable error model.'),
+        'n_reads_learn': ('The minimum number of reads to use when training '
+                          'the error model. This is passed to DADA2 as '
+                          '`--learn_min_reads`. Smaller numbers will result '
+                          'in a shorter run time but a less reliable error '
+                          'model.'),
         'hashed_feature_ids': ('If true, the feature ids in the resulting '
                                'table will be presented as hashes of the '
                                'sequences defining each feature. The hash '
@@ -269,11 +269,11 @@ plugin.methods.register_function(
         'n_threads': ('The number of threads to use for multithreaded '
                       'processing. If 0 is provided, all available cores will '
                       'be used.'),
-        'n_reads_learn': ('The number of reads to use when training the '
-                          'error model. This is passed to DADA2 as the '
-                          '`nreads` argument to `learnErrors`. Smaller '
-                          'numbers will result in a shorter run time but a '
-                          'less reliable error model.'),
+        'n_reads_learn': ('The minimum number of reads to use when training '
+                          'the error model. This is passed to DADA2 as '
+                          '`--learn_min_reads`. Smaller numbers will result '
+                          'in a shorter run time but a less reliable error '
+                          'model.'),
         'hashed_feature_ids': ('If true, the feature ids in the resulting '
                                'table will be presented as hashes of the '
                                'sequences defining each feature. The hash '
@@ -383,11 +383,11 @@ plugin.methods.register_function(
         'n_threads': 'The number of threads to use for multithreaded '
                      'processing. If 0 is provided, all available cores will '
                      'be used.',
-        'n_reads_learn': 'The number of reads to use when training the '
-                         'error model. This is passed to DADA2 as the '
-                         '`nreads` argument to `learnErrors`. Smaller '
-                         'numbers will result in a shorter run time but a '
-                         'less reliable error model.',
+        'n_reads_learn': 'The minimum number of reads to use when training '
+                         'the error model. This is passed to DADA2 as '
+                         '`--learn_min_reads`. Smaller numbers will result '
+                         'in a shorter run time but a less reliable error '
+                         'model.',
         'hashed_feature_ids': 'If true, the feature ids in the resulting '
                               'table will be presented as hashes of the '
                               'sequences defining each feature. The hash '
@@ -522,11 +522,11 @@ plugin.methods.register_function(
         'n_threads': 'The number of threads to use for multithreaded '
                      'processing. If 0 is provided, all available cores will '
                      'be used.',
-        'n_reads_learn': 'The number of reads to use when training the '
-                         'error model. This is passed to DADA2 as the '
-                         '`nreads` argument to `learnErrors`. Smaller '
-                         'numbers will result in a shorter run time but a '
-                         'less reliable error model.',
+        'n_reads_learn': 'The minimum number of reads to use when training '
+                         'the error model. This is passed to DADA2 as '
+                         '`--learn_min_reads`. Smaller numbers will result '
+                         'in a shorter run time but a less reliable error '
+                         'model.',
         'hashed_feature_ids': 'If true, the feature ids in the resulting '
                               'table will be presented as hashes of the '
                               'sequences defining each feature. The hash '


### PR DESCRIPTION
## Summary
- Clarify that `n_reads_learn` is passed through as `--learn_min_reads`.
- Apply the same help text clarification across the denoise actions that expose `n_reads_learn`.

## Test plan
- `python -m py_compile q2_dada2/plugin_setup.py`

## AI disclosure
AI assistance was used for codebase navigation and wording suggestions. I reviewed the relevant q2-dada2 code paths and edited the final change before submitting.

Refs #186.