### PR TITLE
Expose `qualityType` parameter to fix DADA2 misdetection of AVITI/high-quality FASTQ encoding

### DIFF
--- a/q2_dada2/_denoise.py
+++ b/q2_dada2/_denoise.py
@@ -221,7 +221,7 @@ def _denoise_single(demultiplexed_seqs, trunc_len, trim_left, max_ee, trunc_q,
                     max_len, pooling_method, chimera_method,
                     min_fold_parent_over_abundance, allow_one_off,
                     n_threads, n_reads_learn, hashed_feature_ids,
-                    homopolymer_gap_penalty, band_size, retain_all_samples):
+                    homopolymer_gap_penalty, band_size, retain_all_samples, quality_type):
     _check_inputs(**locals())
     if trunc_len != 0 and trim_left >= trunc_len:
         raise ValueError("trim_left (%r) must be smaller than trunc_len (%r)"
@@ -255,7 +255,9 @@ def _denoise_single(demultiplexed_seqs, trunc_len, trim_left, max_ee, trunc_q,
                '--num_threads', str(n_threads),
                '--learn_min_reads', str(n_reads_learn),
                '--homopolymer_gap_penalty', str(homopolymer_gap_penalty),
-               '--band_size', str(band_size)]
+               '--band_size', str(band_size),
+               '--quality_type', str(quality_type),
+               ]
         try:
             run_commands([cmd])
         except subprocess.CalledProcessError as e:
@@ -281,7 +283,8 @@ def denoise_single(demultiplexed_seqs: SingleLanePerSampleSingleEndFastqDirFmt,
                    allow_one_off: bool = False,
                    n_threads: int = 1, n_reads_learn: int = 1000000,
                    hashed_feature_ids: bool = True,
-                   retain_all_samples: bool = True
+                   retain_all_samples: bool = True,
+                   quality_type: str = 'Auto',
                    ) -> (biom.Table, DNAIterator,
                          qiime2.Metadata, qiime2.Metadata):
     return _denoise_single(
@@ -300,7 +303,9 @@ def denoise_single(demultiplexed_seqs: SingleLanePerSampleSingleEndFastqDirFmt,
         hashed_feature_ids=hashed_feature_ids,
         homopolymer_gap_penalty='NULL',
         band_size='16',
-        retain_all_samples=retain_all_samples)
+        retain_all_samples=retain_all_samples,
+        quality_type=quality_type,
+    )
 
 
 def denoise_paired(demultiplexed_seqs: SingleLanePerSamplePairedEndFastqDirFmt,
@@ -318,7 +323,8 @@ def denoise_paired(demultiplexed_seqs: SingleLanePerSamplePairedEndFastqDirFmt,
                    n_threads: int = 1, n_reads_learn: int = 1000000,
                    hashed_feature_ids: bool = True,
                    retain_all_samples: bool = True,
-                   retain_unmerged: bool = False
+                   retain_unmerged: bool = False,
+                   quality_type: str = 'Auto',
                    ) -> (biom.Table, DNAIterator,
                          qiime2.Metadata, qiime2.Metadata):
     _check_inputs(**locals())
@@ -376,7 +382,9 @@ def denoise_paired(demultiplexed_seqs: SingleLanePerSamplePairedEndFastqDirFmt,
                '--allow_one_off', str(allow_one_off),
                '--num_threads', str(n_threads),
                '--learn_min_reads', str(n_reads_learn),
-               '--retain_unmerged', str(retain_unmerged)]
+               '--retain_unmerged', str(retain_unmerged),
+               '--quality_type', str(quality_type),
+               ]
         try:
             run_commands([cmd])
         except subprocess.CalledProcessError as e:
@@ -420,7 +428,8 @@ def denoise_pyro(demultiplexed_seqs: SingleLanePerSampleSingleEndFastqDirFmt,
                  allow_one_off: bool = False,
                  n_threads: int = 1, n_reads_learn: int = 250000,
                  hashed_feature_ids: bool = True,
-                 retain_all_samples: bool = True
+                 retain_all_samples: bool = True,
+                 quality_type: str = 'Auto',
                  ) -> (biom.Table, DNAIterator,
                        qiime2.Metadata, qiime2.Metadata):
     return _denoise_single(
@@ -439,7 +448,9 @@ def denoise_pyro(demultiplexed_seqs: SingleLanePerSampleSingleEndFastqDirFmt,
         hashed_feature_ids=hashed_feature_ids,
         homopolymer_gap_penalty='1',
         band_size='32',
-        retain_all_samples=retain_all_samples)
+        retain_all_samples=retain_all_samples,
+        quality_type=quality_type,
+    )
 
 
 def denoise_ccs(demultiplexed_seqs: SingleLanePerSampleSingleEndFastqDirFmt,
@@ -453,7 +464,8 @@ def denoise_ccs(demultiplexed_seqs: SingleLanePerSampleSingleEndFastqDirFmt,
                 allow_one_off: bool = False,
                 n_threads: int = 1, n_reads_learn: int = 1000000,
                 hashed_feature_ids: bool = True,
-                retain_all_samples: bool = True
+                retain_all_samples: bool = True,
+                quality_type: str = 'Auto',
                 ) -> (biom.Table, DNAIterator,
                       qiime2.Metadata, qiime2.Metadata):
     _check_inputs(**locals())
@@ -498,7 +510,9 @@ def denoise_ccs(demultiplexed_seqs: SingleLanePerSampleSingleEndFastqDirFmt,
                '--num_threads', str(n_threads),
                '--learn_min_reads', str(n_reads_learn),
                '--homopolymer_gap_penalty', 'NULL',
-               '--band_size', '32']
+               '--band_size', '32',
+               '--quality_type', str(quality_type),
+               ]
 
         if adapter is not None:
             cmd += ['--reverse_primer', str(adapter)]

--- a/q2_dada2/assets/run_dada.R
+++ b/q2_dada2/assets/run_dada.R
@@ -127,6 +127,7 @@
 #                 number turns off banding (i.e. full Needleman-Wunsch).
 #    Ex: 32
 #
+# 23)
 
 # error handling -----------------
 options(error = function() {
@@ -208,9 +209,11 @@ option_list = list(
   make_option(c("--retain_unmerged"), action="store", default='FALSE', type='character',
               help="If TRUE, denoised paired reads that fail merging are retained as space-concatenated sequences."),
   make_option(c("--homopolymer_gap_penalty"), action="store", default='NULL', type='character',
-              help="The cost of gaps in homopolymer regions (>=3 repeated bases).Default is NULL, which causes homopolymer gaps to be treated as normal gaps."),
+              help="The cost of gaps in homopolymer regions (>=3 repeated bases). Default is NULL, which causes homopolymer gaps to be treated as normal gaps."),
   make_option(c("--band_size"), action="store", default='NULL', type='character',
-              help="When set, banded Needleman-Wunsch alignments are performed.")
+              help="When set, banded Needleman-Wunsch alignments are performed."),
+  make_option(c("--quality_type"), action="store", default='Auto', type='character',
+              help="The quality encoding of the fastq file(s). If set to 'Auto' (the default) dada2 will attempt to auto-detect the encoding.")
 )
 opt = parse_args(OptionParser(option_list=option_list))
 
@@ -247,6 +250,7 @@ allowOneOff <-if(opt$allow_one_off=='NULL') NULL else as.logical(opt$allow_one_o
 nthreads <- if(opt$num_threads=='NULL') NULL else as.integer(opt$num_threads)
 nreads.learn <- if(opt$learn_min_reads=='NULL') NULL else as.integer(opt$learn_min_reads)
 retain.unmerged <- if(opt$retain_unmerged=='NULL') FALSE else as.logical(opt$retain_unmerged)
+qualityType <- opt$quality_type
 linked.concat.delim <- "NNNNNNNNNN"
 # The following args are not directly exposed to end users in q2-dada2,
 # but rather indirectly, via the methods `denoise-single` and `denoise-pyro`.
@@ -478,7 +482,7 @@ if(inp.dirR =='NULL'){#for CCS/sinlge/pyro read analysis
   cat("4) Denoise samples ")
   cat("\n")
   for(j in seq(length(filts))) {
-    drp <- derepFastq(filts[[j]])
+    drp <- derepFastq(filts[[j]], qualityType=qualityType)
     dds[[j]] <- dada(drp, err=err, multithread=multithread,HOMOPOLYMER_GAP_PENALTY=HOMOPOLYMER_GAP_PENALTY,
                      BAND_SIZE=BAND_SIZE, verbose=FALSE)
     cat(".")
@@ -495,7 +499,7 @@ if(inp.dirR =='NULL'){#for CCS/sinlge/pyro read analysis
     ### \pseudo_priors code copied from dada2.R
     ### code copied from previous loop through samples in this script
     for(j in seq(length(filts))) {
-      drp <- derepFastq(filts[[j]])
+      drp <- derepFastq(filts[[j]], qualityType=qualityType)
       dds[[j]] <- dada(drp, err=err, multithread=multithread,
                        priors=pseudo_priors, HOMOPOLYMER_GAP_PENALTY=HOMOPOLYMER_GAP_PENALTY,
                        BAND_SIZE=BAND_SIZE, verbose=FALSE)
@@ -516,9 +520,9 @@ if(inp.dirR =='NULL'){#for CCS/sinlge/pyro read analysis
   cat("3) Denoise samples ")
 
   for(j in seq(length(filts))) {
-    drpF <- derepFastq(filts[[j]])
+    drpF <- derepFastq(filts[[j]], qualityType=qualityType)
     ddsF[[j]] <- dada(drpF, err=err, multithread=multithread, verbose=FALSE)
-    drpR <- derepFastq(filtsR[[j]])
+    drpR <- derepFastq(filtsR[[j]], qualityType=qualityType)
     ddsR[[j]] <- dada(drpR, err=errR, multithread=multithread, verbose=FALSE)
     cat(".")
   }
@@ -537,10 +541,10 @@ if(inp.dirR =='NULL'){#for CCS/sinlge/pyro read analysis
     ### \pseudo_priors code copied from dada2.R
     ### code copied from previous loop through samples in this script
     for(j in seq(length(filts))) {
-      drpF <- derepFastq(filts[[j]])
+      drpF <- derepFastq(filts[[j]], qualityType=qualityType)
       ddsF[[j]] <- dada(drpF, err=err, priors=pseudo_priorsF,
                         multithread=multithread, verbose=FALSE)
-      drpR <- derepFastq(filtsR[[j]])
+      drpR <- derepFastq(filtsR[[j]], qualityType=qualityType)
       ddsR[[j]] <- dada(drpR, err=errR, priors=pseudo_priorsR,
                         multithread=multithread, verbose=FALSE)
       cat(".")
@@ -551,8 +555,8 @@ if(inp.dirR =='NULL'){#for CCS/sinlge/pyro read analysis
 
   ### Now loop through and do merging
   for(j in seq(length(filts))) {
-    drpF <- derepFastq(filts[[j]])
-    drpR <- derepFastq(filtsR[[j]])
+    drpF <- derepFastq(filts[[j]], qualityType=qualityType)
+    drpR <- derepFastq(filtsR[[j]], qualityType=qualityType)
     # we are intentionally not using `justConcatenate = TRUE` here; that sets
     # the "accept" column to TRUE for all pairs in mergePairs and would collapse
     # true merged and rescued unmerged reads into the same "merged" count

--- a/q2_dada2/assets/run_dada.R
+++ b/q2_dada2/assets/run_dada.R
@@ -127,7 +127,8 @@
 #                 number turns off banding (i.e. full Needleman-Wunsch).
 #    Ex: 32
 #
-# 23)
+# 23) quality_type - The quality encoding of the fastq file(s). If set to 'Auto'
+#                    (the default) dada2 will attempt to auto-detect the encoding
 
 # error handling -----------------
 options(error = function() {

--- a/q2_dada2/plugin_setup.py
+++ b/q2_dada2/plugin_setup.py
@@ -24,6 +24,7 @@ from ._dada_stats import plot_base_transitions
 
 _POOL_OPT = {'pseudo', 'independent'}
 _CHIM_OPT = {'consensus', 'none'}
+_QUAL_OPT = {'Auto', 'FastqQuality', 'SFastqQuality'}
 P_retain_unmerged, T_paired_representative_sequences = qiime2.plugin.TypeMap({
     qiime2.plugin.Choices(True):
         FeatureData[LinkedSequence],
@@ -70,7 +71,10 @@ plugin.methods.register_function(
                 'n_threads': qiime2.plugin.Threads,
                 'n_reads_learn': qiime2.plugin.Int,
                 'hashed_feature_ids': qiime2.plugin.Bool,
-                'retain_all_samples': qiime2.plugin.Bool},
+                'retain_all_samples': qiime2.plugin.Bool,
+                'quality_type': qiime2.plugin.Str %
+                                qiime2.plugin.Choices(_QUAL_OPT),
+                },
     outputs=[('table', FeatureTable[Frequency]),
              ('representative_sequences', FeatureData[Sequence]),
              ('denoising_stats', SampleData[DADA2Stats]),
@@ -144,7 +148,10 @@ plugin.methods.register_function(
         'retain_all_samples': 'If True all samples input to dada2 will be '
                               'retained in the output of dada2, if false '
                               'samples with zero total frequency are removed '
-                              'from the table.'
+                              'from the table.',
+        'quality_type': "The quality encoding of the fastq file(s). If set to "
+                        "'Auto' (the default) dada2 will attempt to "
+                        "auto-detect the encoding.",
     },
     output_descriptions={
         'table': 'The resulting feature table.',
@@ -188,7 +195,10 @@ plugin.methods.register_function(
                 'n_reads_learn': qiime2.plugin.Int,
                 'hashed_feature_ids': qiime2.plugin.Bool,
                 'retain_all_samples': qiime2.plugin.Bool,
-                'retain_unmerged': qiime2.plugin.Bool % P_retain_unmerged},
+                'retain_unmerged': qiime2.plugin.Bool % P_retain_unmerged,
+                'quality_type': qiime2.plugin.Str %
+                                qiime2.plugin.Choices(_QUAL_OPT),
+                },
     outputs=[('table', FeatureTable[Frequency]),
              ('representative_sequences', T_paired_representative_sequences),
              ('denoising_stats', SampleData[DADA2Stats]),
@@ -299,7 +309,10 @@ plugin.methods.register_function(
             'including these features in the table and sequences. Note that '
             'the reverse read is reverse-complemented and thus both read '
             'directions can be expected to map to the same strand.'
-        )
+        ),
+        'quality_type': "The quality encoding of the fastq file(s). If set to "
+                        "'Auto' (the default) dada2 will attempt to "
+                        "auto-detect the encoding.",
     },
     output_descriptions={
         'table': 'The resulting feature table.',
@@ -338,7 +351,10 @@ plugin.methods.register_function(
                 'n_threads': qiime2.plugin.Threads,
                 'n_reads_learn': qiime2.plugin.Int,
                 'hashed_feature_ids': qiime2.plugin.Bool,
-                'retain_all_samples': qiime2.plugin.Bool},
+                'retain_all_samples': qiime2.plugin.Bool,
+                'quality_type': qiime2.plugin.Str %
+                                qiime2.plugin.Choices(_QUAL_OPT),
+                },
     outputs=[('table', FeatureTable[Frequency]),
              ('representative_sequences', FeatureData[Sequence]),
              ('denoising_stats', SampleData[DADA2Stats]),
@@ -414,7 +430,10 @@ plugin.methods.register_function(
         'retain_all_samples': 'If True all samples input to dada2 will be '
                               'retained in the output of dada2, if false '
                               'samples with zero total frequency are removed '
-                              'from the table.'
+                              'from the table.',
+        'quality_type': "The quality encoding of the fastq file(s). If set to "
+                        "'Auto' (the default) dada2 will attempt to "
+                        "auto-detect the encoding.",
     },
     output_descriptions={
         'table': 'The resulting feature table.',
@@ -450,7 +469,10 @@ plugin.methods.register_function(
                 'n_threads': qiime2.plugin.Threads,
                 'n_reads_learn': qiime2.plugin.Int,
                 'hashed_feature_ids': qiime2.plugin.Bool,
-                'retain_all_samples': qiime2.plugin.Bool},
+                'retain_all_samples': qiime2.plugin.Bool,
+                'quality_type': qiime2.plugin.Str %
+                                qiime2.plugin.Choices(_QUAL_OPT),
+                },
     outputs=[('table', FeatureTable[Frequency]),
              ('representative_sequences', FeatureData[Sequence]),
              ('denoising_stats', SampleData[DADA2Stats]),
@@ -553,7 +575,10 @@ plugin.methods.register_function(
         'retain_all_samples': 'If True all samples input to dada2 will be '
                               'retained in the output of dada2, if false '
                               'samples with zero total frequency are removed '
-                              'from the table.'
+                              'from the table.',
+        'quality_type': "The quality encoding of the fastq file(s). If set to "
+                        "'Auto' (the default) dada2 will attempt to auto-detect "
+                        "the encoding.",
     },
     output_descriptions={
         'table': 'The resulting feature table.',


### PR DESCRIPTION
While processing AVITI sequencing data (excellent quality, Q40–Q45), the denoising step consistently failed with:
`Invalid derep$quals matrix. Quality values must be positive integers`

This traces back to `benjjneb/dada2#1549`.
Internally, dada2 relies on ShortRead to load FASTQ files, and ShortRead auto-detects the quality encoding as either `FastqQuality` (ASCII 33–126, phred-offset 33) or `SFastqQuality` (ASCII 64–126, phred-offset 64). Under certain conditions, AVITI reads are misidentified as `SFastqQuality`, causing an offset of 64 to be applied instead of 33 and producing the error above

This patch exposes the `qualityType` parameter from `ShortRead` / `dada2` to `q2-dada2`, allowing users to explicitly set the encoding and bypass the faulty auto-detection

A (cleaner) fix would be for q2-dada2 to set `qualityType="FastqQuality"` by default, since it seems QIIME2 already enforces phred-offset 33 upstream

AI Disclosure
Not used